### PR TITLE
fix: enable route generation prompt when controller already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5] - 2025-10-11
+
+### Fixed
+- Interactive Route Management: Fixed route generation prompt not appearing when controller already exists (fixes #13)
+  - Route generation now triggers when using `--controller` or `--all` flags, even if controller file already exists
+  - Users will now see the interactive prompt: "Would you like to add API routes for this resource?"
+  - Ensures documented Interactive Route Management feature works as expected
+
+### Improved
+- Route handling logic: Controller generation now properly tracks when controller is requested, not just when created
+- All 114 tests passing with 276 assertions
+
 ## [0.3.4] - 2025-10-11
 
 ### Fixed
@@ -223,7 +235,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contributing guidelines
 - Security policy
 
-[Unreleased]: https://github.com/iamgerwin/laravel-api-scaffold/compare/0.3.4...HEAD
+[Unreleased]: https://github.com/iamgerwin/laravel-api-scaffold/compare/0.3.5...HEAD
+[0.3.5]: https://github.com/iamgerwin/laravel-api-scaffold/compare/0.3.4...0.3.5
 [0.3.4]: https://github.com/iamgerwin/laravel-api-scaffold/compare/0.3.3...0.3.4
 [0.3.3]: https://github.com/iamgerwin/laravel-api-scaffold/compare/0.3.2...0.3.3
 [0.3.2]: https://github.com/iamgerwin/laravel-api-scaffold/compare/0.3.1...0.3.2

--- a/src/Commands/MakeServiceCommand.php
+++ b/src/Commands/MakeServiceCommand.php
@@ -512,6 +512,10 @@ class MakeServiceCommand extends Command
         $controllerName = "{$this->modelName}Controller";
         $filePath = app_path("Http/Controllers/{$controllerName}.php");
 
+        // Mark controller as generated/requested for route handling
+        // This ensures route prompts appear even if controller already exists
+        $this->controllerGenerated = true;
+
         if ($this->fileExists($filePath)) {
             return;
         }
@@ -535,7 +539,6 @@ class MakeServiceCommand extends Command
         $this->ensureDirectoryExists($filePath);
         File::put($filePath, $content);
         $this->createdFiles[] = $filePath;
-        $this->controllerGenerated = true;
         $this->info("Created controller: {$filePath}");
     }
 


### PR DESCRIPTION
## Summary

This PR fixes the Interactive Route Management feature to work when the controller file already exists. Previously, the route generation prompt would not appear if you ran the command with `--all` or `--controller` flags when the controller already existed.

## Problem

When running:
```bash
php artisan make:service-api Product --all
```

If the `ProductController.php` file already existed, the route generation prompt would not appear, even though the README documents this feature as available.

## Root Cause

The `controllerGenerated` flag was only set to `true` after successfully creating the controller file. If the file already existed, the method would return early (line 516) before setting the flag, which meant `handleRouteGeneration()` would skip route prompts.

## Solution

Moved the `$this->controllerGenerated = true` assignment to occur BEFORE the file existence check. This ensures that:

1. Route prompts appear when using `--controller` or `--all` flags
2. Works regardless of whether controller is newly created or already exists
3. Interactive Route Management feature works as documented

## Changes

- ✅ Updated `generateController()` method in `MakeServiceCommand.php`
- ✅ Set `controllerGenerated` flag before file existence check
- ✅ Updated CHANGELOG.md for version 0.3.5
- ✅ All 114 tests passing (276 assertions)
- ✅ Laravel Pint code style validation passed

## Testing

```bash
vendor/bin/pest
# ✓ All 114 tests passed

vendor/bin/pint  
# ✓ Code style validation passed
```

## Behavior After Fix

When running:
```bash
php artisan make:service-api Product --all
```

Users will now see:
```
Would you like to add API routes for this resource? (yes/no)
```

Followed by route organization options:
- Append to `routes/api.php`
- Create separate file `routes/api/product.php`

Fixes #13